### PR TITLE
📝 (whatsapp.service.ts): eliminar console.log('Bot Creds')

### DIFF
--- a/apps/whatsapp/src/whatsapp.service.ts
+++ b/apps/whatsapp/src/whatsapp.service.ts
@@ -118,7 +118,6 @@ export class WhatsappService {
         replaceParamsFromString(twilioPhoneNumber, 'whatsapp:', ''),
       );
 
-      console.log('Bot Creds', botCredentials);
       const key = `google-cloud-credentials/${botCredentials.id}.json`;
 
       const credentials: JWTInput = await getFileContent(


### PR DESCRIPTION
Eliminar la declaración de console.log('Bot Creds') para mejorar la limpieza y la legibilidad del código. Los mensajes de consola de depuración no son necesarios en este punto y pueden eliminarse de forma segura.